### PR TITLE
Don't redraw text with each display change

### DIFF
--- a/src/display_tft.cpp
+++ b/src/display_tft.cpp
@@ -8,25 +8,26 @@
 #include <TFT_eSPI.h> 
 
 #define X_CURSOR_START 10
+#define X_CURSOR_NUMBER_START 120
 #define LIVE_Y_CURSOR_START 20
 #define PEAK_Y_CURSOR_START 60
-#define FILL_RECT_WIDTH 180
+#define FILL_RECT_WIDTH 60
 #define FILL_RECT_HEIGHT 30
 
 TFT_eSPI tft = TFT_eSPI(); // unfortunately the pins must be set in the library file manually, and cant be set programmatically
 
 void displayForce(long force) {
-  tft.fillRect(X_CURSOR_START, LIVE_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK);
-  tft.setCursor(X_CURSOR_START, LIVE_Y_CURSOR_START);
+  tft.fillRect(X_CURSOR_NUMBER_START, LIVE_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK);
+  tft.setCursor(X_CURSOR_NUMBER_START, LIVE_Y_CURSOR_START);
   tft.setTextColor(TFT_BLUE, TFT_BLACK);
-  tft.printf("live: %ld", force);
+  tft.printf("%ld", force);
 }
 
 void displayMaxForce(long force) {
-  tft.fillRect(X_CURSOR_START, PEAK_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK); // need to make this extend further right
-  tft.setCursor(X_CURSOR_START, PEAK_Y_CURSOR_START);
+  tft.fillRect(X_CURSOR_NUMBER_START, PEAK_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK); // need to make this extend further right
+  tft.setCursor(X_CURSOR_NUMBER_START, PEAK_Y_CURSOR_START);
   tft.setTextColor(TFT_GREEN, TFT_BLACK);
-  tft.printf("peak: %ld", force);
+  tft.printf("%ld", force);
 }
 
 void displayInit(){
@@ -40,10 +41,19 @@ void displayInit(){
   tft.printf("SLACK");
   tft.setCursor(X_CURSOR_START, PEAK_Y_CURSOR_START);
   tft.printf("CELL");
+
 }
 
 void displayClearBuffer(){
-//   no buffer to clear for TFT displays
+  tft.fillRect(X_CURSOR_START, LIVE_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK);
+  tft.setCursor(X_CURSOR_START, LIVE_Y_CURSOR_START);
+  tft.setTextColor(TFT_BLUE, TFT_BLACK);
+  tft.print("live:");
+
+  tft.fillRect(X_CURSOR_START, PEAK_Y_CURSOR_START, FILL_RECT_WIDTH, FILL_RECT_HEIGHT, TFT_BLACK);
+  tft.setCursor(X_CURSOR_START, PEAK_Y_CURSOR_START);
+  tft.setTextColor(TFT_GREEN, TFT_BLACK);
+  tft.print("peak:");
 }
 
 #endif //Board filter


### PR DESCRIPTION
Fixes #17 

I originally was redrawing the text with each change in force. This change redraws only the numbers after setting the text once.