### PR TITLE
Sleep and automatic standby power handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ Based on the original SlackCell by [Markus Rampp](https://markusrampp.eu/SlackCe
 - Great for standard slackline needs (measuring your line tension for parklines or highlines)
 - Suitable for slackline science (measurement speed as fast as possible with readily available parts)
 
-First calibrate your loadcell by loading *Calibration.ino*, and use the values displayed with your known weight to alter the calibration values in *SlackCell.ino*. Then load and run the latter file with your updated values, and you have a dyno!
-
 ## Code Notes:
-Current features are displaying current and max force on integrated OLED, and writing forces to microSD.
+Current features are:
+- Displaying current and max force on integrated OLED
+- Writing forces to microSD
+- Power management
+    - Ultra low power standby, which enables having a battery connected constantly, without draining the battery
+    - Automatically turn off when battery is low, to protect the battery
+    - Battery percentage estimation and display
 
 Current sampling rate:
 - Need to retest sampling rates for new hardware
@@ -43,7 +47,14 @@ Developed to work with different boards. Supported right now are: Heltec Wifi Ki
 
 Making your own SlackCell requires about $100 worth of parts, a soldering iron, and very minimal soldering experience. The process is as easy as soldering the pin headers to the boards, soldering the boards and loadcell wires to the pcb, and screwing the eye bolts into the load cell.
 
-Before use, a calibration sketch must be uploaded to the microcontroller and the loadcell has to be calibrated with a known weight. The calibration data has to be changed in the slackcell code, and then it can be uploaded to the board - *voila!* you have your own dynamometer!
+Most stock HX711 modules are limited in hardware to 10Hz sampling rate. This can be changed to 80Hz, but requires advanced soldering skills. Instructions can be found on [Instructables](https://www.instructables.com/How-to-Convert-Your-HX-711-Board-From-10Hz-to-80Hz/)
+
+### Calibration
+#### Loadcell
+Before use, calibrate your loadcell by uploading *Calibration.ino* with the Arduino IDE, and use the values displayed with your known weight to alter the calibration values in *include/user_config.h*. Then load and run the code like described [above](#how-to-use-the-code) with your updated values, and *voila!* you have your own dynamometer!
+
+#### Battery
+Every battery behaves differently, to get accurate battery percentage estimations follow the instructions in [analysis/plotter.py](analysis/plotter.py).
 
 ### Approximate price:
 

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -1,3 +1,11 @@
+import matplotlib.pyplot as plt
+from scipy.optimize import curve_fit
+import re
+from datetime import timedelta
+from io import StringIO
+import numpy as np
+import argparse
+
 description = """
 This python file analyzes a csv file to estimate remaining battery run time based on battery voltage..
 
@@ -17,83 +25,108 @@ How to use:
 10. Flash code again
 """
 
-import argparse
-import numpy as np
-from io import StringIO
-from datetime import timedelta
-from scipy.optimize import curve_fit
-import matplotlib.pyplot as plt
 
-#print all floats with 3 decimal places
-np.set_printoptions(formatter={'float':"{0:0.3f}".format})
+# print all floats with 3 decimal places
+np.set_printoptions(formatter={'float': "{0:0.3f}".format})
 
-#setup interactive plot
+# setup interactive plot
 plt.ion()
 
-#make it nice to use from the terminal
+# make it nice to use from the terminal
 parser = argparse.ArgumentParser("plotter.py", formatter_class=argparse.RawDescriptionHelpFormatter, description=description)
 parser.add_argument("file", help="Path to csv file containing recording of one full battery drain", type=str)
 args = parser.parse_args()
 
+# The titles in the csv files with _ instead of whitespace. Change here if renamed in the generation code
+ids_title = 'Reading_ID'
+times_title = 'Time_(ms)'
+battery_title = 'Battery_Voltage_(V)'
+forces_title = 'Force_(N)'
+
+datatypes_per_title = {
+    ids_title: np.int_,
+    times_title: np.int_,
+    battery_title: np.float64,
+    forces_title: np.int_
+}
 
 ######################
-### Helper functions
+# Helper functions
 
-# if there are subsequent equal values in an array, returns the last index of the groups
-# [0, 1, 1, 5, 5, 5, 2, 6, 7, 2, 2, 9] => [0, 2, 5, 6, 7, 8, 10, 11]
+
 def index_of_unique_values(a):
-    # works by getting the indeces where two shifted versions of "a" are different and adding the last index manually
+    """
+    if there are subsequent equal values in an array, returns the last index of the groups
+    [0, 1, 1, 5, 5, 5, 2, 6, 7, 2, 2, 9] => [0, 2, 5, 6, 7, 8, 10, 11]
+    """
+    # works by getting the indices where two shifted versions of "a" are different and adding the last index manually
     return np.concatenate([np.where(a[:-1] != a[1:])[0], [len(a) - 1]])
 
 
-#represents voltages with two decimal places as int. Example 3.73 V => 373, 4.15 V => 415
+# represents voltages with two decimal places as int. Example 3.73 V => 373, 4.15 V => 415
 def voltage_to_steps(v: float):
-    return int(round(v*100))
+    return int(round(v * 100))
 
 
 ########################
-### Main part
+# Main part
 
 with open(args.file) as f:
     all_text = f.read()
-    recordings = [s for s in all_text.split("Reading ID, Time (ms), Battery Voltage (V), Force (N)") if s.strip()!= '']
+    # split by any line starting with 'Reading', which should be or title headings, but include the titles in the array
+    recordings_split = [s for s in re.split(r'(Reading.*)', all_text) if s.strip() != '']
+    # collect pairs of csv titles and the data of the induvidual recordings
+    recordings = zip(recordings_split[::2], recordings_split[1::2])
 
-    for idx, rec in enumerate(recordings):
-        id_time_force_arr = np.genfromtxt(StringIO(rec), delimiter=",", dtype=[('ids', int), ('times', int), ('battery', float), ('forces', int)])
-        #kick out weird outliers in the force
-        id_time_force_filtered = id_time_force_arr[id_time_force_arr['forces'] != -104]
+    for idx, (rec_header, rec) in enumerate(recordings):
+        print(rec_header)
+        # Get the titles as array
+        # also trims whitespace and replaces whitespaces in titles with _
+        titles = [s.replace(' ', '_') for s in re.split(r'\s*,\s*', rec_header)]
 
-        ids = id_time_force_filtered['ids']
-        times = id_time_force_filtered['times']
-        battery = id_time_force_filtered['battery']
-        forces = id_time_force_filtered['forces']
-    
+        needed_titles = [ids_title, times_title, battery_title, forces_title]
+        if any((delim not in titles for delim in needed_titles)):
+            print(f'Skipping recording. One or more fields are missing from the csv Header, expecting {needed_titles}')
+            continue
+
+        id_time_force_arr = np.genfromtxt(
+            StringIO(rec), delimiter=",", dtype=[datatypes_per_title.get(n) for n in titles], names=titles, deletechars=''
+        )
+        # kick out weird outliers in the force
+        id_time_force_filtered = id_time_force_arr[id_time_force_arr[forces_title] != -104]
+
+        ids = id_time_force_filtered[ids_title]
+        times = id_time_force_filtered[times_title]
+        battery = id_time_force_filtered[battery_title]
+        forces = id_time_force_filtered[forces_title]
+
         td = timedelta(milliseconds=int(times[-1]))
-        print(f"idx: {idx}, samples: {ids[-1]}, recording time (hh:mm:ss): {str(td)}, recording time seconds: {td.seconds}, min force (N): {np.min(forces)}, max force (N): {np.max(forces)}")
+        print(f"idx: {idx}, samples: {ids[-1]}, recording time (hh:mm:ss): {str(td)}, recording time seconds: {td.seconds}")
+        print(f"min force (N): {np.min(forces)}, max force (N): {np.max(forces)}")
         unique_battery_indices = index_of_unique_values(battery)[1:]
 
-        real_percent = 100 - ids[unique_battery_indices]/max(ids) * 100        
+        real_percent = 100 - ids[unique_battery_indices] / max(ids) * 100
 
-        #the code to fit the curve comes from here: https://stackoverflow.com/a/75598551
+        # the code to fit the curve comes from here: https://stackoverflow.com/a/75598551
 
         x = battery[unique_battery_indices]
         y = real_percent
 
         sums = {}
 
-        #create a dictionary which contains summed up percentages and a counter for each voltage step
+        # create a dictionary which contains summed up percentages and a counter for each voltage step
         for i, v in enumerate(x):
             v_int = voltage_to_steps(v)
             if v_int in sums:
                 sums[v_int] = (sums[v_int][0] + real_percent[i], sums[v_int][1] + 1)
             else:
                 sums[v_int] = (real_percent[i], 1)
-        
-        # from the sums and counters generate the average per voltage step
-        look_up_dict = {voltage: sum_and_counter[0] / sum_and_counter[1] for voltage, sum_and_counter in sums.items()}        
 
+        # from the sums and counters generate the average per voltage step
+        look_up_dict = {voltage: sum_and_counter[0] / sum_and_counter[1] for voltage, sum_and_counter in sums.items()}
 
         # returns percentage for given voltage based on averaged values from above
+
         def look_up(v):
             v_int = voltage_to_steps(v)
             if v_int in look_up_dict:
@@ -101,7 +134,7 @@ with open(args.file) as f:
 
         # a curve fitting well for the lipo discharge behavior, comes from here: https://electronics.stackexchange.com/a/551667
         def lipo_curve(x, a, b, c, d):
-            return a - (a/(((1 + (x/b)**c)**d)))
+            return a - (a / (((1 + (x / b)**c)**d)))
 
         # fit lipo_curve to x, y
         # the original values, also come from the same post: https://electronics.stackexchange.com/a/551667
@@ -109,18 +142,16 @@ with open(args.file) as f:
 
         def lipo_curve_formula_str(a, b, c, d):
             return f"{a:.3f}f - ({a:.3f}f/((pow(1 + pow(x/{b:.3f}f,{c:.3f}f),{d:.3f}f))))"
-        
-        
+
         # parameters for lut generation
         min_vol = min(battery[unique_battery_indices])
         max_vol = max(battery[unique_battery_indices])
         lut_length = voltage_to_steps(max_vol) - voltage_to_steps(min_vol) + 1
-        
+
         # generate one float voltage for each space in the lut
         lut_v = np.linspace(min_vol, max_vol, num=lut_length)
 
         lut = np.minimum(np.rint(lipo_curve(lut_v, *coefs_lipo_curve)), 100)
-
 
         print(coefs_lipo_curve)
         print(lipo_curve_formula_str(*coefs_lipo_curve))
@@ -140,12 +171,15 @@ with open(args.file) as f:
 
         y_data_lut = [lut[voltage_to_steps(v) - voltage_to_steps(min_vol)] for v in x_data]
 
-        print("Paste and replace the following lines in include/user_config.h: \n")
+        if (min_vol > 3.45 or max_vol < 4.1):
+            print("\nWARNING: this recording doesn't seem to contain a complete battery drain. Use another on to replace your LUT")
+
+        print("\nPaste and replace the following lines in include/user_config.h: \n")
 
         print(f"const uint16_t min_lut_voltage = {voltage_to_steps(min_vol)};")
         print(f"const uint16_t max_lut_voltage = {voltage_to_steps(max_vol)};")
         c_lut = (
-            'const uint8_t battery_percent_lut [] = {' + 
+            'const uint8_t battery_percent_lut [] = {' +
             ', '.join(map(str, map(int, lut))) +
             '};\n'
         )
@@ -159,4 +193,4 @@ with open(args.file) as f:
         plt.legend(['Battery readings', 'Fitted lipo curve', 'Averaged battery readings', 'Look up table'])
         plt.xlabel('Battery Voltage in V')
         plt.ylabel('Battery percentage')
-        plt.show(block = True)
+        plt.show(block=True)

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -10,7 +10,7 @@ from scipy.ndimage import gaussian_filter1d
 description = """
 This python file analyzes a csv file to estimate remaining battery run time based on battery voltage..
 
-Requirements: python installation with external libraries Numpy and Scipy installed.
+Requirements: python installation with external libraries Matplotlib, Numpy and Scipy installed.
 
 How to use:
 1. Make sure HAS_BATTERY_READOUT feature is activated (include/pins.h)
@@ -22,7 +22,7 @@ How to use:
 6. Let it run until it turn off due to low battery. (That will take hours, depending on the battery connected)
 7. Copy only the section of the latest recording from the sd card into a new csv file on your computer.
 8. Run in the terminal: python analysis/plotter.py path_to_your_recording.csv
-9. Paste the LUT into your code as instructed in the serial output  of the script
+9. Paste the LUT into your code as instructed in the serial output of the script
 10. Flash code again
 """
 

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -1,0 +1,162 @@
+description = """
+This python file analyzes a csv file to estimate remaining battery run time based on battery voltage..
+
+Requirements: python installation with external libraries Numpy and Scipy installed.
+
+How to use:
+1. Make sure HAS_BATTERY_READOUT feature is activated (include/pins.h)
+   and standby feature deactivated (set variable automaticStandbyActive in src/power.cpp to false) and flash code onto SlackCell
+2. Fully charge SlackCell
+3. Unplug from charger
+4. Make sure SD card is inserted
+5. Restart SlackCell to restart recording (which will include battery voltage over time)
+6. Let it run until it turn off due to low battery. (That will take hours, depending on the battery connected)
+7. Copy only the section of the latest recording from the sd card into a new csv file on your computer.
+8. Run in the terminal: python analysis/plotter.py path_to_your_recording.csv
+9. Paste the LUT into your code as instructed in the serial output  of the script
+10. Flash code again
+"""
+
+import argparse
+import numpy as np
+from io import StringIO
+from datetime import timedelta
+from scipy.optimize import curve_fit
+import matplotlib.pyplot as plt
+
+#print all floats with 3 decimal places
+np.set_printoptions(formatter={'float':"{0:0.3f}".format})
+
+#setup interactive plot
+plt.ion()
+
+#make it nice to use from the terminal
+parser = argparse.ArgumentParser("plotter.py", formatter_class=argparse.RawDescriptionHelpFormatter, description=description)
+parser.add_argument("file", help="Path to csv file containing recording of one full battery drain", type=str)
+args = parser.parse_args()
+
+
+######################
+### Helper functions
+
+# if there are subsequent equal values in an array, returns the last index of the groups
+# [0, 1, 1, 5, 5, 5, 2, 6, 7, 2, 2, 9] => [0, 2, 5, 6, 7, 8, 10, 11]
+def index_of_unique_values(a):
+    # works by getting the indeces where two shifted versions of "a" are different and adding the last index manually
+    return np.concatenate([np.where(a[:-1] != a[1:])[0], [len(a) - 1]])
+
+
+#represents voltages with two decimal places as int. Example 3.73 V => 373, 4.15 V => 415
+def voltage_to_steps(v: float):
+    return int(round(v*100))
+
+
+########################
+### Main part
+
+with open(args.file) as f:
+    all_text = f.read()
+    recordings = [s for s in all_text.split("Reading ID, Time (ms), Battery Voltage (V), Force (N)") if s.strip()!= '']
+
+    for idx, rec in enumerate(recordings):
+        id_time_force_arr = np.genfromtxt(StringIO(rec), delimiter=",", dtype=[('ids', int), ('times', int), ('battery', float), ('forces', int)])
+        #kick out weird outliers in the force
+        id_time_force_filtered = id_time_force_arr[id_time_force_arr['forces'] != -104]
+
+        ids = id_time_force_filtered['ids']
+        times = id_time_force_filtered['times']
+        battery = id_time_force_filtered['battery']
+        forces = id_time_force_filtered['forces']
+    
+        td = timedelta(milliseconds=int(times[-1]))
+        print(f"idx: {idx}, samples: {ids[-1]}, recording time (hh:mm:ss): {str(td)}, recording time seconds: {td.seconds}, min force (N): {np.min(forces)}, max force (N): {np.max(forces)}")
+        unique_battery_indices = index_of_unique_values(battery)[1:]
+
+        real_percent = 100 - ids[unique_battery_indices]/max(ids) * 100        
+
+        #the code to fit the curve comes from here: https://stackoverflow.com/a/75598551
+
+        x = battery[unique_battery_indices]
+        y = real_percent
+
+        sums = {}
+
+        #create a dictionary which contains summed up percentages and a counter for each voltage step
+        for i, v in enumerate(x):
+            v_int = voltage_to_steps(v)
+            if v_int in sums:
+                sums[v_int] = (sums[v_int][0] + real_percent[i], sums[v_int][1] + 1)
+            else:
+                sums[v_int] = (real_percent[i], 1)
+        
+        # from the sums and counters generate the average per voltage step
+        look_up_dict = {voltage: sum_and_counter[0] / sum_and_counter[1] for voltage, sum_and_counter in sums.items()}        
+
+
+        # returns percentage for given voltage based on averaged values from above
+        def look_up(v):
+            v_int = voltage_to_steps(v)
+            if v_int in look_up_dict:
+                return look_up_dict[voltage_to_steps(v)]
+
+        # a curve fitting well for the lipo discharge behavior, comes from here: https://electronics.stackexchange.com/a/551667
+        def lipo_curve(x, a, b, c, d):
+            return a - (a/(((1 + (x/b)**c)**d)))
+
+        # fit lipo_curve to x, y
+        # the original values, also come from the same post: https://electronics.stackexchange.com/a/551667
+        coefs_lipo_curve, _ = curve_fit(lipo_curve, x, y, [123, 3.7, 80, 0.165])
+
+        def lipo_curve_formula_str(a, b, c, d):
+            return f"{a:.3f}f - ({a:.3f}f/((pow(1 + pow(x/{b:.3f}f,{c:.3f}f),{d:.3f}f))))"
+        
+        
+        # parameters for lut generation
+        min_vol = min(battery[unique_battery_indices])
+        max_vol = max(battery[unique_battery_indices])
+        lut_length = voltage_to_steps(max_vol) - voltage_to_steps(min_vol) + 1
+        
+        # generate one float voltage for each space in the lut
+        lut_v = np.linspace(min_vol, max_vol, num=lut_length)
+
+        lut = np.minimum(np.rint(lipo_curve(lut_v, *coefs_lipo_curve)), 100)
+
+
+        print(coefs_lipo_curve)
+        print(lipo_curve_formula_str(*coefs_lipo_curve))
+
+        def mse(func, x, y, coefs):
+            return np.mean((func(x, *coefs) - y)**2)
+
+        print(f"Mean square error: {mse(lipo_curve, x, y, coefs_lipo_curve)}")
+
+        # initialize some points
+        x_data = np.linspace(min(x), max(x), 50)
+        # transform x_data to y-axis values via lipo_curve
+        y_data = lipo_curve(x_data, *coefs_lipo_curve)
+        # plot the points
+
+        y_data_dict = [look_up(v) for v in x_data]
+
+        y_data_lut = [lut[voltage_to_steps(v) - voltage_to_steps(min_vol)] for v in x_data]
+
+        print("Paste and replace the following lines in include/user_config.h: \n")
+
+        print(f"const uint16_t min_lut_voltage = {voltage_to_steps(min_vol)};")
+        print(f"const uint16_t max_lut_voltage = {voltage_to_steps(max_vol)};")
+        c_lut = (
+            'const uint8_t battery_percent_lut [] = {' + 
+            ', '.join(map(str, map(int, lut))) +
+            '};\n'
+        )
+
+        print(c_lut)
+
+        plt.plot(x, y, 'r')
+        plt.plot(x_data, y_data)
+        plt.plot(x_data, y_data_dict, 'g')
+        plt.plot(x_data, y_data_lut)
+        plt.legend(['Battery readings', 'Fitted lipo curve', 'Averaged battery readings', 'Look up table'])
+        plt.xlabel('Battery Voltage in V')
+        plt.ylabel('Battery percentage')
+        plt.show(block = True)

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -1,10 +1,11 @@
-import matplotlib.pyplot as plt
-from scipy.ndimage import gaussian_filter1d
-import re
+import argparse
 from datetime import timedelta
 from io import StringIO
+import re
+
+import matplotlib.pyplot as plt
 import numpy as np
-import argparse
+from scipy.ndimage import gaussian_filter1d
 
 description = """
 This python file analyzes a csv file to estimate remaining battery run time based on battery voltage..

--- a/analysis/plotter.py
+++ b/analysis/plotter.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-from scipy.optimize import curve_fit
+from scipy.ndimage import gaussian_filter1d
 import re
 from datetime import timedelta
 from io import StringIO
@@ -35,7 +35,14 @@ plt.ion()
 # make it nice to use from the terminal
 parser = argparse.ArgumentParser("plotter.py", formatter_class=argparse.RawDescriptionHelpFormatter, description=description)
 parser.add_argument("file", help="Path to csv file containing recording of one full battery drain", type=str)
+parser.add_argument(
+    "--smooth", metavar="sigma",
+    help="Sigma for a Gaussian filter to smooth out the battery lut, defaults to no filter",
+    default=0, type=float
+)
 args = parser.parse_args()
+
+do_smoothing = args.smooth > 0
 
 # The titles in the csv files with _ instead of whitespace. Change here if renamed in the generation code
 ids_title = 'Reading_ID'
@@ -54,18 +61,9 @@ datatypes_per_title = {
 # Helper functions
 
 
-def index_of_unique_values(a):
-    """
-    if there are subsequent equal values in an array, returns the last index of the groups
-    [0, 1, 1, 5, 5, 5, 2, 6, 7, 2, 2, 9] => [0, 2, 5, 6, 7, 8, 10, 11]
-    """
-    # works by getting the indices where two shifted versions of "a" are different and adding the last index manually
-    return np.concatenate([np.where(a[:-1] != a[1:])[0], [len(a) - 1]])
-
-
-# represents voltages with two decimal places as int. Example 3.73 V => 373, 4.15 V => 415
 def voltage_to_steps(v: float):
-    return int(round(v * 100))
+    "represents voltages with two decimal places as int. Example 3.73 V => 373, 4.15 V => 415"
+    return np.int_(np.round(v * 100))
 
 
 ########################
@@ -75,7 +73,7 @@ with open(args.file) as f:
     all_text = f.read()
     # split by any line starting with 'Reading', which should be or title headings, but include the titles in the array
     recordings_split = [s for s in re.split(r'(Reading.*)', all_text) if s.strip() != '']
-    # collect pairs of csv titles and the data of the induvidual recordings
+    # collect pairs of csv titles and the data of the individual recordings
     recordings = zip(recordings_split[::2], recordings_split[1::2])
 
     for idx, (rec_header, rec) in enumerate(recordings):
@@ -94,6 +92,8 @@ with open(args.file) as f:
         )
         # kick out weird outliers in the force
         id_time_force_filtered = id_time_force_arr[id_time_force_arr[forces_title] != -104]
+        # kick out 0V from battery reading, occurs at the beginning, before voltage value is available
+        id_time_force_filtered = id_time_force_filtered[id_time_force_filtered[battery_title] != 0]
 
         ids = id_time_force_filtered[ids_title]
         times = id_time_force_filtered[times_title]
@@ -103,19 +103,13 @@ with open(args.file) as f:
         td = timedelta(milliseconds=int(times[-1]))
         print(f"idx: {idx}, samples: {ids[-1]}, recording time (hh:mm:ss): {str(td)}, recording time seconds: {td.seconds}")
         print(f"min force (N): {np.min(forces)}, max force (N): {np.max(forces)}")
-        unique_battery_indices = index_of_unique_values(battery)[1:]
 
-        real_percent = 100 - ids[unique_battery_indices] / max(ids) * 100
-
-        # the code to fit the curve comes from here: https://stackoverflow.com/a/75598551
-
-        x = battery[unique_battery_indices]
-        y = real_percent
+        real_percent = 100 - ids / max(ids) * 100
 
         sums = {}
 
         # create a dictionary which contains summed up percentages and a counter for each voltage step
-        for i, v in enumerate(x):
+        for i, v in enumerate(battery):
             v_int = voltage_to_steps(v)
             if v_int in sums:
                 sums[v_int] = (sums[v_int][0] + real_percent[i], sums[v_int][1] + 1)
@@ -125,54 +119,29 @@ with open(args.file) as f:
         # from the sums and counters generate the average per voltage step
         look_up_dict = {voltage: sum_and_counter[0] / sum_and_counter[1] for voltage, sum_and_counter in sums.items()}
 
-        # returns percentage for given voltage based on averaged values from above
-
-        def look_up(v):
-            v_int = voltage_to_steps(v)
-            if v_int in look_up_dict:
-                return look_up_dict[voltage_to_steps(v)]
-
-        # a curve fitting well for the lipo discharge behavior, comes from here: https://electronics.stackexchange.com/a/551667
-        def lipo_curve(x, a, b, c, d):
-            return a - (a / (((1 + (x / b)**c)**d)))
-
-        # fit lipo_curve to x, y
-        # the original values, also come from the same post: https://electronics.stackexchange.com/a/551667
-        coefs_lipo_curve, _ = curve_fit(lipo_curve, x, y, [123, 3.7, 80, 0.165])
-
-        def lipo_curve_formula_str(a, b, c, d):
-            return f"{a:.3f}f - ({a:.3f}f/((pow(1 + pow(x/{b:.3f}f,{c:.3f}f),{d:.3f}f))))"
-
         # parameters for lut generation
-        min_vol = min(battery[unique_battery_indices])
-        max_vol = max(battery[unique_battery_indices])
+        min_vol = min(battery)
+        max_vol = max(battery)
         lut_length = voltage_to_steps(max_vol) - voltage_to_steps(min_vol) + 1
 
         # generate one float voltage for each space in the lut
         lut_v = np.linspace(min_vol, max_vol, num=lut_length)
 
-        lut = np.minimum(np.rint(lipo_curve(lut_v, *coefs_lipo_curve)), 100)
+        # contains potential incomplete pairs of voltage with percentage based on averaged values from above
+        dict_as_arr = np.array(sorted(look_up_dict.items()))
 
-        print(coefs_lipo_curve)
-        print(lipo_curve_formula_str(*coefs_lipo_curve))
+        # fill the potential missing voltage with linear interpolation
+        lut = np.interp(voltage_to_steps(lut_v), dict_as_arr[:, 0], dict_as_arr[:, 1], 0, 100)
+        # smooth the values
+        if do_smoothing:
+            lut_gau = gaussian_filter1d(lut, args.smooth, mode="nearest")
 
-        def mse(func, x, y, coefs):
-            return np.mean((func(x, *coefs) - y)**2)
+            # make sure the lut starts with 0% and ends with 100%
+            lut_gau[0] = 0
+            lut_gau[-1] = 100
 
-        print(f"Mean square error: {mse(lipo_curve, x, y, coefs_lipo_curve)}")
-
-        # initialize some points
-        x_data = np.linspace(min(x), max(x), 50)
-        # transform x_data to y-axis values via lipo_curve
-        y_data = lipo_curve(x_data, *coefs_lipo_curve)
-        # plot the points
-
-        y_data_dict = [look_up(v) for v in x_data]
-
-        y_data_lut = [lut[voltage_to_steps(v) - voltage_to_steps(min_vol)] for v in x_data]
-
-        if (min_vol > 3.45 or max_vol < 4.1):
-            print("\nWARNING: this recording doesn't seem to contain a complete battery drain. Use another on to replace your LUT")
+        if (min_vol > 3.4 or max_vol < 4.1):
+            print("\nWARNING: this recording doesn't seem to contain a complete battery drain. Use another one to replace your LUT")
 
         print("\nPaste and replace the following lines in include/user_config.h: \n")
 
@@ -180,17 +149,22 @@ with open(args.file) as f:
         print(f"const uint16_t max_lut_voltage = {voltage_to_steps(max_vol)};")
         c_lut = (
             'const uint8_t battery_percent_lut [] = {' +
-            ', '.join(map(str, map(int, lut))) +
+            ', '.join(map(str, map(int, np.round(lut_gau if do_smoothing else lut)))) +
             '};\n'
         )
-
         print(c_lut)
 
-        plt.plot(x, y, 'r')
-        plt.plot(x_data, y_data)
-        plt.plot(x_data, y_data_dict, 'g')
-        plt.plot(x_data, y_data_lut)
-        plt.legend(['Battery readings', 'Fitted lipo curve', 'Averaged battery readings', 'Look up table'])
+        # plot the recorded battery values and the lut
+        plt.plot(battery, real_percent, 'r')
+        plt.plot(lut_v, np.round(lut))
+        if do_smoothing:
+            plt.plot(lut_v, np.round(lut_gau))
+
+        plt.legend([
+            'Battery readings',
+            'Look up table',
+            'Look up table Gaussian filter',
+        ])
         plt.xlabel('Battery Voltage in V')
         plt.ylabel('Battery percentage')
         plt.show(block=True)

--- a/include/display.h
+++ b/include/display.h
@@ -10,6 +10,8 @@ void displayForce(long force);
 void displayMaxForce(long force);
 void displayInit();
 void displayClearBuffer();
+void displaySleep();
+void displayWakeup();
 
 
 #endif //DISPLAY_SEEN

--- a/include/display.h
+++ b/include/display.h
@@ -12,6 +12,8 @@ void displayInit();
 void displayClearBuffer();
 void displaySleep();
 void displayWakeup();
+void displayInfo(float batteryVoltage);
+void displayBatteryLow();
 
 
 #endif //DISPLAY_SEEN

--- a/include/display.h
+++ b/include/display.h
@@ -12,8 +12,9 @@ void displayInit();
 void displayClearBuffer();
 void displaySleep();
 void displayWakeup();
-void displayInfo(float batteryVoltage);
+void displayInfo(float batteryVoltage, uint8_t batteryPercent);
 void displayBatteryLow();
+void displayBatteryIcon(int percent);
 
 
 #endif //DISPLAY_SEEN

--- a/include/pins.h
+++ b/include/pins.h
@@ -3,15 +3,19 @@ This file contains the pin definitions for the different supported boards.
 
 BOARD_xxxx: This define is set by the PLATFORM IO build system, look in platformio.ini under build-flags of your board.
 USE_VEXT: if defined, enables usage of switchable external voltage. Only enable if support on your specific board
-    Using this supply for connected devices, like HX711 and SD card will reduce power consumption in deep sleep
-USE_BUTTON: if defined, enables usage of a button to toggle the switch state
-USE_SWITCH: if defined, enables usage of a switch to toggle the switch state
+    Using this supply for connected devices, like HX711 and SD card will reduce power consumption in deep sleep.
+    If the used dev board does not support switching external power, this functionality can be achieved by adding a mosfet circuit and defining the variable "Vext" to the pin of the mosfet controlling the external power.
+HAS_BATTERY_READOUT: define if your board/circuit does support reading out the battery voltage
+USE_RESET_BUTTON: if defined, enables usage of a button to toggle display updates and reset peak force with a long press
+USE_SWITCH: if defined, enables usage of a switch to toggle display updates
+USE_INFO_BUTTON: if defined, enables showing battery information on press of a button, depending on HAS_BATTERY_READOUT
 USE_VSPI: if defined, enables usage of the VSPI bus for the SD card. This is required for some boards with SPI
     screen interfaces to prevent SPI conflicts with the SD card
 CUSTOM_SPI_PINS: if defined, enables usage of custom SPI pins for the screen. This is required for boards that do not 
     use the default SPI pins for the screen connection
 READING_AVG_TIMES: number of readings to average for the HX711. 
     For boards where the display cannot keep up with readings, average values to send to the display.
+    Set to 1 to disable averaging.
 */
 
 //Wrapper to include this file only once
@@ -56,10 +60,19 @@ const uint8_t SD_CS_PIN = 33;
 const uint8_t LOADCELL_SCK_PIN = 40;
 const uint8_t LOADCELL_DOUT_PIN = 41;
 //Controls
-#define USE_BUTTON
-const uint8_t BUTTON_PIN = 4;
+#define USE_RESET_BUTTON
+const uint8_t RESET_BUTTON_PIN = 4;
+#define USE_INFO_BUTTON
+const uint8_t INFO_BUTTON_PIN = 3;
 #define USE_SLEEP
 const gpio_num_t POWER_BUTTON_PIN = GPIO_NUM_2;
+
+#define HAS_BATTERY_READOUT
+//Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
+const uint8_t VBAT_ADC_PIN  = 1;
+const uint8_t VBAT_READ_CONTROL_PIN = 37; // Heltec V3 GPIO to toggle VBatt read connection, this pin enables disabling the voltage divider connecting the battery voltage and therefore conserving power, especially important in sleep mode
+const adc_attenuation_t VBAT_ADC_ATTENUATION = ADC_2_5db; //For the Heltec V3 this limits the measuring range to 1.05V which is enough, after the battery voltage passed through the voltage divider, see: https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogsetattenuation
+const float VBAT_CONVERSION_FACTOR = 0.001f / (100.0f / (100.0f + 390.0f)); //0.001 converts from mV to V, the other values come from the builtin voltage divider, which has the resistors R1 = 390kOhm and R2 = 100kOhm
 
 #define USE_VEXT
 #define READING_AVG_TIMES 7
@@ -77,12 +90,17 @@ const uint8_t SD_CS_PIN = 2;
 // HX711 circuit wiring
 const uint8_t LOADCELL_SCK_PIN = 33;
 const uint8_t LOADCELL_DOUT_PIN = 32;
-#define USE_BUTTON
-const uint8_t BUTTON_PIN = 0;
+#define USE_RESET_BUTTON
+const uint8_t RESET_BUTTON_PIN = 0;
 
 #define USE_VSPI
 #define READING_AVG_TIMES 1
 
+#endif //BOARD_TTGO_DISPLAY
+
+//Checks
+#if defined(USE_INFO_BUTTON) && !defined(HAS_BATTERY_READOUT)
+#error "Info feature only works when battery readout is supported!"
 #endif
 
 #endif //PINS_SEEN

--- a/include/pins.h
+++ b/include/pins.h
@@ -17,7 +17,6 @@ READING_AVG_TIMES: number of readings to average for the HX711.
 //Wrapper to include this file only once
 #ifndef PINS_SEEN
 #define PINS_SEEN
-#endif
 
 #if defined(BOARD_HELTEC_V2)
 // internal OLED wiring
@@ -58,7 +57,9 @@ const uint8_t LOADCELL_SCK_PIN = 40;
 const uint8_t LOADCELL_DOUT_PIN = 41;
 //Controls
 #define USE_BUTTON
-const uint8_t BUTTON_PIN = 2;
+const uint8_t BUTTON_PIN = 4;
+#define USE_SLEEP
+const gpio_num_t POWER_BUTTON_PIN = GPIO_NUM_2;
 
 #define USE_VEXT
 #define READING_AVG_TIMES 7
@@ -83,3 +84,5 @@ const uint8_t BUTTON_PIN = 0;
 #define READING_AVG_TIMES 1
 
 #endif
+
+#endif //PINS_SEEN

--- a/include/pins.h
+++ b/include/pins.h
@@ -2,13 +2,18 @@
 This file contains the pin definitions for the different supported boards. 
 
 BOARD_xxxx: This define is set by the PLATFORM IO build system, look in platformio.ini under build-flags of your board.
+
+Following Macros feature flags are supported. If they are indented, they are dependent on the flag one level higher
+
 USE_VEXT: if defined, enables usage of switchable external voltage. Only enable if support on your specific board
     Using this supply for connected devices, like HX711 and SD card will reduce power consumption in deep sleep.
     If the used dev board does not support switching external power, this functionality can be achieved by adding a mosfet circuit and defining the variable "Vext" to the pin of the mosfet controlling the external power.
-HAS_BATTERY_READOUT: define if your board/circuit does support reading out the battery voltage
+USE_SLEEP: if defined, allows to put the SlackCell into deep sleep with a power button and/or automatically with standby mode
+    HAS_BATTERY_READOUT: define if your board/circuit does support reading out the battery voltage, only useful, when USE_SLEEP is enabled
+        RECORD_BATTERY_VOLTAGE: if defined, enables exporting the battery voltage into the csv recording
+        USE_INFO_BUTTON: if defined, enables showing battery information on press of a button, depending on HAS_BATTERY_READOUT
 USE_RESET_BUTTON: if defined, enables usage of a button to toggle display updates and reset peak force with a long press
 USE_SWITCH: if defined, enables usage of a switch to toggle display updates
-USE_INFO_BUTTON: if defined, enables showing battery information on press of a button, depending on HAS_BATTERY_READOUT
 USE_VSPI: if defined, enables usage of the VSPI bus for the SD card. This is required for some boards with SPI
     screen interfaces to prevent SPI conflicts with the SD card
 CUSTOM_SPI_PINS: if defined, enables usage of custom SPI pins for the screen. This is required for boards that do not 
@@ -68,11 +73,14 @@ const uint8_t INFO_BUTTON_PIN = 3;
 const gpio_num_t POWER_BUTTON_PIN = GPIO_NUM_2;
 
 #define HAS_BATTERY_READOUT
+#ifdef HAS_BATTERY_READOUT
+#define RECORD_BATTERY_VOLTAGE
 //Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
 const uint8_t VBAT_ADC_PIN  = 1;
 const uint8_t VBAT_READ_CONTROL_PIN = 37; // Heltec V3 GPIO to toggle VBatt read connection, this pin enables disabling the voltage divider connecting the battery voltage and therefore conserving power, especially important in sleep mode
 const adc_attenuation_t VBAT_ADC_ATTENUATION = ADC_2_5db; //For the Heltec V3 this limits the measuring range to 1.05V which is enough, after the battery voltage passed through the voltage divider, see: https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogsetattenuation
 const float VBAT_CONVERSION_FACTOR = 0.001f / (100.0f / (100.0f + 390.0f)); //0.001 converts from mV to V, the other values come from the builtin voltage divider, which has the resistors R1 = 390kOhm and R2 = 100kOhm
+#endif
 
 #define USE_VEXT
 #define READING_AVG_TIMES 7

--- a/include/pins.h
+++ b/include/pins.h
@@ -78,8 +78,8 @@ const gpio_num_t POWER_BUTTON_PIN = GPIO_NUM_2;
 //Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
 const uint8_t VBAT_ADC_PIN  = 1;
 const uint8_t VBAT_READ_CONTROL_PIN = 37; // Heltec V3 GPIO to toggle VBatt read connection, this pin enables disabling the voltage divider connecting the battery voltage and therefore conserving power, especially important in sleep mode
-const adc_attenuation_t VBAT_ADC_ATTENUATION = ADC_2_5db; //For the Heltec V3 this limits the measuring range to 1.05V which is enough, after the battery voltage passed through the voltage divider, see: https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogsetattenuation
-const float VBAT_CONVERSION_FACTOR = 0.001f / (100.0f / (100.0f + 390.0f)); //0.001 converts from mV to V, the other values come from the builtin voltage divider, which has the resistors R1 = 390kOhm and R2 = 100kOhm
+const adc_attenuation_t VBAT_ADC_ATTENUATION = ADC_0db; //For the Heltec V3 this limits the measuring range to 950mV which is enough, after the battery voltage passed through the voltage divider, see: https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogsetattenuation
+const float VBAT_CONVERSION_FACTOR = (0.001f / (100.0f / (100.0f + 390.0f))); //0.001 converts from mV to V, the other values come from the builtin voltage divider, which has the resistors R1 = 390kOhm and R2 = 100kOhm
 #endif
 
 #define USE_VEXT

--- a/include/pins.h
+++ b/include/pins.h
@@ -107,8 +107,16 @@ const uint8_t RESET_BUTTON_PIN = 0;
 #endif //BOARD_TTGO_DISPLAY
 
 //Checks
+#if defined(HAS_BATTERY_READOUT) && !defined(USE_SLEEP)
+#error "Battery readout feature only works when USE_SLEEP is activated!"
+#endif
+
 #if defined(USE_INFO_BUTTON) && !defined(HAS_BATTERY_READOUT)
 #error "Info feature only works when battery readout is supported!"
+#endif
+
+#if defined(RECORD_BATTERY_VOLTAGE) && !defined(HAS_BATTERY_READOUT)
+#error "Record Battery voltage feature only works when battery readout is supported!"
 #endif
 
 #endif //PINS_SEEN

--- a/include/power.h
+++ b/include/power.h
@@ -2,9 +2,12 @@
 #ifndef POWER_SEEN
 #define POWER_SEEN
 
+#include "pins.h"
+
 /// Does all the power handling needed on startup
 /// Depending on the configuration, this can include:
 ///  - Handling wake up of deep sleep
+///  - Checking for sufficient battery voltage
 ///  - Setting up button to let the user put the unit to sleep
 ///  - Controlling external power to connected devices
 void powerInit();
@@ -13,5 +16,8 @@ void powerInit();
 /// @param reading The last read force, this is needed for the automatic standby.
 void powerTick(long reading);
 
+#ifdef HAS_BATTERY_READOUT
+float readBatLevel();
+#endif //HAS_BATTERY_READOUT
 
 #endif //POWER_SEEN

--- a/include/power.h
+++ b/include/power.h
@@ -1,0 +1,17 @@
+//Wrapper to include this file only once
+#ifndef POWER_SEEN
+#define POWER_SEEN
+
+/// Does all the power handling needed on startup
+/// Depending on the configuration, this can include:
+///  - Handling wake up of deep sleep
+///  - Setting up button to let the user put the unit to sleep
+///  - Controlling external power to connected devices
+void powerInit();
+
+/// Should be called in the main loop, to query the button and execute standby if needed.
+/// @param reading The last read force, this is needed for the automatic standby.
+void powerTick(long reading);
+
+
+#endif //POWER_SEEN

--- a/include/power.h
+++ b/include/power.h
@@ -18,6 +18,8 @@ void powerTick(long reading);
 
 #ifdef HAS_BATTERY_READOUT
 float readBatLevel();
+
+extern float batteryVoltage;
 #endif //HAS_BATTERY_READOUT
 
 #endif //POWER_SEEN

--- a/include/power.h
+++ b/include/power.h
@@ -19,6 +19,7 @@ void powerTick(long reading);
 #ifdef HAS_BATTERY_READOUT
 float readBatLevel();
 
+extern uint8_t batteryPercent;
 extern float batteryVoltage;
 #endif //HAS_BATTERY_READOUT
 

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -1,0 +1,31 @@
+/*
+Config file for variables that will be different for every device
+
+Important: Please only commit structural changes to this file, no edited values (unless other default value is desired)
+If git pull fails due to local changes in this file solve with the stash:
+
+```
+git stash push -m "user_config" -- include/user_config.h
+git pull
+git stash pop #Now resolve any potential merge conflicts
+```
+
+*/
+
+//Wrapper to include this file only once
+#ifndef USER_CONFIG_SEEN
+#define USER_CONFIG_SEEN
+
+#include "Arduino.h"
+
+#ifdef HAS_BATTERY_READOUT
+//These values should be calibrated for every different battery to obtain accurate battery percentage. 
+//Battery percentage is not proportional to battery voltage. The following look up table (LUT) maps voltage to percentage, based upon measurements of the battery draining.
+//Use analysis/plotter.py to analyze a recording of a discharge from full to empty battery.
+//Look up by multiplying the voltage by 100, rounding to int and subtract min_lut_voltage, that will be your array index
+const uint16_t min_lut_voltage = 330;
+const uint16_t max_lut_voltage = 434;
+const uint8_t battery_percent_lut [] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 57, 59, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 79, 80, 81, 82, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 97, 98, 99, 100, 100, 100, 100, 100, 100, 100, 100};
+#endif //HAS_BATTERY_READOUT
+
+#endif //USER_CONFIG_SEEN

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -18,6 +18,10 @@ git stash pop #Now resolve any potential merge conflicts
 
 #include "Arduino.h"
 
+//These values must be calibrated for every loadcell to obtain any useful force reading
+const long LOADCELL_OFFSET = 2330;
+const float LOADCELL_DIVIDER_N = -232;
+
 #ifdef HAS_BATTERY_READOUT
 //These values should be calibrated for every different battery to obtain accurate battery percentage. 
 //Battery percentage is not proportional to battery voltage. The following look up table (LUT) maps voltage to percentage, based upon measurements of the battery draining.

--- a/include/user_config.h
+++ b/include/user_config.h
@@ -30,6 +30,10 @@ const float LOADCELL_DIVIDER_N = -232;
 const uint16_t min_lut_voltage = 330;
 const uint16_t max_lut_voltage = 434;
 const uint8_t battery_percent_lut [] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 57, 59, 61, 63, 64, 66, 67, 69, 70, 72, 73, 75, 76, 77, 79, 80, 81, 82, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 97, 98, 99, 100, 100, 100, 100, 100, 100, 100, 100};
+
+//If the reported battery voltage doesn't match what you read with a voltmeter, you can adjust it here.
+//If you change it, you'll need to redo the full battery drain and execute the analysis script again to calculate a new lut
+const float VBAT_CORRECTION_FACTOR = 1;
 #endif //HAS_BATTERY_READOUT
 
 #endif //USER_CONFIG_SEEN

--- a/src/display_heltec.cpp
+++ b/src/display_heltec.cpp
@@ -7,6 +7,8 @@
 #include "pins.h"
 #include "U8g2lib.h" //library for OLED
 
+bool initialized = false;
+
 U8G2_SSD1306_128X64_NONAME_F_HW_I2C   u8g2(U8G2_R2, OLED_RESET_PIN, OLED_CLOCK_PIN, OLED_DATA_PIN); //setup display connection
 
 //number: number to display
@@ -45,10 +47,25 @@ void displayInit(){
   u8g2.drawStr(0, 0, "SLACK");
   u8g2.drawStr(0, 36, "CELL");
   u8g2.sendBuffer();
+
+  initialized = true;
 }
 
 void displayClearBuffer(){
   u8g2.clearBuffer();
+}
+
+void displaySleep(){
+  // This function also get's called when waking up from deep sleep,
+  // where the display will not be initialized yet
+  // This condition prevents error's in this case
+  if(initialized){
+    u8g2.setPowerSave(1);
+  }
+}
+
+void displayWakeup(){
+  u8g2.setPowerSave(0);
 }
 
 #endif //Board filter

--- a/src/display_heltec.cpp
+++ b/src/display_heltec.cpp
@@ -51,6 +51,26 @@ void displayInit(){
   initialized = true;
 }
 
+void displayBatteryLow(){
+  u8g2.clearBuffer();
+  //switching to smaller font, to fit the entire message
+  u8g2.setFont(u8g2_font_lubR19_tf);
+  u8g2.setFontPosTop();
+  u8g2.drawStr(0, 0, "Battery");
+  u8g2.drawStr(0, 36, "too low!");
+  u8g2.sendBuffer();
+  //not resetting font to default, because MCU will sleep, and therefore reset before the next display action anyways
+}
+
+void displayInfo(float batteryVoltage){
+  char buffer[7];
+  snprintf(buffer, 7, "%.2f V", batteryVoltage);
+  displayClearBuffer();
+  u8g2.drawStr(0, 0, buffer);
+
+  u8g2.sendBuffer();
+}
+
 void displayClearBuffer(){
   u8g2.clearBuffer();
 }

--- a/src/display_heltec.cpp
+++ b/src/display_heltec.cpp
@@ -13,8 +13,9 @@ U8G2_SSD1306_128X64_NONAME_F_HW_I2C   u8g2(U8G2_R2, OLED_RESET_PIN, OLED_CLOCK_P
 
 //number: number to display
 //line: y position on screen to start drawing on
+//x: x position on screen to start drawing on
 //maxLength: Maximum number of letters the screen can display in one row
-void displayNdigits(long number,  uint8_t line, uint8_t maxLength){
+void displayNdigits(long number,  uint8_t line, uint8_t x, uint8_t maxLength){
   // Long range is +-2,147,483,648
   char bufferF[12] = {};
   ltoa(number, bufferF, 10);
@@ -23,24 +24,28 @@ void displayNdigits(long number,  uint8_t line, uint8_t maxLength){
   for (int i = 0; i < strlen(bufferF); i++) {
     bufferLCD[maxLength - strlen(bufferF) + i] = bufferF[i];
   }
-  u8g2.drawStr(0, line, bufferLCD);
+  u8g2.drawStr(x, line, bufferLCD);
   u8g2.sendBuffer();
 }
 
 void displayForce(long force) {
-  displayNdigits(force, 0, 6);
+  displayNdigits(force, 0, 21, 5);
 }
 
 void displayMaxForce(long force) {
-  displayNdigits(force, 36, 6);
+  displayNdigits(force, 36, 21, 5);
+}
+
+void displaySetDefaultFont(){
+  u8g2.setFont(u8g2_font_inb21_mf);
+  u8g2.setFontPosTop();
 }
 
 void displayInit(){
   u8g2.setBusClock(1000000);
   u8g2.begin();
   u8g2.setPowerSave(0);
-  u8g2.setFont(u8g2_font_inb21_mf);
-  u8g2.setFontPosTop();
+  displaySetDefaultFont();
 
 
   u8g2.clearBuffer();
@@ -50,6 +55,7 @@ void displayInit(){
 
   initialized = true;
 }
+
 
 void displayBatteryLow(){
   u8g2.clearBuffer();
@@ -62,13 +68,37 @@ void displayBatteryLow(){
   //not resetting font to default, because MCU will sleep, and therefore reset before the next display action anyways
 }
 
-void displayInfo(float batteryVoltage){
-  char buffer[7];
-  snprintf(buffer, 7, "%.2f V", batteryVoltage);
+//Draws a battery icon in the bottom left corner
+//percent: battery percentage, expected input range 0 to 100, everything else will be clamped to those limits
+void displayBatteryIcon(int percent){
+  static const char BATTERY_SYMBOL_CHARGING = '=';
+  static const char BATTERY_SYMBOL_EMPTY = '5';
+  static const char BATTERY_SYMBOL_FULL = '<';
+  
+  percent = constrain(percent, 0, 100);
+  
+  //Changing font to display battery icons instead of letters: https://github.com/olikraus/u8g2/wiki/fntgrpu8g#battery24
+  u8g2.setFont(u8g2_font_battery24_tr);
+  u8g2.setFontPosBottom();
+  //mapping percent from 0 to 100 to the battery icons in the specific battery font.
+  //It only works, because the battery symbols are consecutive in the font
+  char display_str[2] = {(char) roundf(percent/100.0f*(BATTERY_SYMBOL_FULL - BATTERY_SYMBOL_EMPTY) + BATTERY_SYMBOL_EMPTY), '\0'};
+  u8g2.drawStr(0, 64, display_str);
+  u8g2.sendBuffer();
+
+  displaySetDefaultFont();
+}
+
+void displayInfo(float batteryVoltage, uint8_t batteryPercent){
+  char buffer[15];
+  //smaller font to fit more characters
+  u8g2.setFont(u8g2_font_lubR18_tf);
+  //%% prints the literal character %
+  snprintf(buffer, 15, "%.2fV %u%%", batteryVoltage, batteryPercent);
   displayClearBuffer();
   u8g2.drawStr(0, 0, buffer);
-
   u8g2.sendBuffer();
+  displaySetDefaultFont();
 }
 
 void displayClearBuffer(){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ Tested with and recommended for Heltec WifiKit32 V2 or V3 controller
 
 #include "pins.h"
 #include "display.h"
+#include "power.h"
 
 #define CSV_NAME "/slackcell.txt" // TODO: not sure if these should live in another file
 #define CSV_HEADER "Reading ID, Time (ms), Force (N) \r\n"
@@ -32,11 +33,6 @@ void writeSD(int readingID, long timeNow, long force);
 void writeFile(fs::FS &fs, const char * path, const char * message);
 void appendFile(fs::FS &fs, const char * path, const char * message);
 void Display(void * parameter);
-
-#ifdef USE_VEXT
-void VextON(void);
-void VextOFF(void);
-#endif
 
 #ifdef USE_VSPI
 SPIClass spiVspi(VSPI);
@@ -83,14 +79,11 @@ bool Switch_state = false;
 
 void setup() {
   Serial.begin(baud);
+  powerInit();
+
   Serial.println("Welcome to SlackCell!");
   Serial.print("Sketch:   ");   Serial.println(__FILE__);
   Serial.print("Uploaded: ");   Serial.println(__DATE__);
-
-#ifdef USE_VEXT
-  //turn on external devices
-  VextON();
-#endif //USE_VEXT
 
 #ifdef USE_SWITCH
   // Setting up the Switch
@@ -220,6 +213,9 @@ void loop() {
     if(sd_ready && recording){
       writeSD(readingID, timeNow, reading);
     }
+
+    powerTick(reading);
+
     //increasing readingID outside of if, because it is also used when recording is off
     readingID++;
   }
@@ -294,19 +290,3 @@ void resetMaxForce(){
   maxForce = 0;
 }
 #endif
-
-#ifdef USE_VEXT
-//Turn external power supply on
-void VextON(void)
-{
-  pinMode(Vext,OUTPUT);
-  digitalWrite(Vext, LOW);
-}
-
-//Turn external power supply off
-void VextOFF(void) //Vext default OFF
-{
-  pinMode(Vext,OUTPUT);
-  digitalWrite(Vext, HIGH);
-}
-#endif //USE_VEXT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@ Tested with and recommended for Heltec WifiKit32 V2 or V3 controller
 #include "SD.h"
 
 #include "pins.h"
+#include "user_config.h"
 #include "display.h"
 #include "power.h"
 
@@ -62,8 +63,6 @@ bool print_info = false; //get's set from the button callback above
 
 const long baud = 115200;
 
-const long LOADCELL_OFFSET = 2330;
-const float LOADCELL_DIVIDER_N = -232;
 const float LOADCELL_DIVIDER_kg = LOADCELL_DIVIDER_N * 9.81;
 const float LOADCELL_DIVIDER_lb = LOADCELL_DIVIDER_N * 4.448;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,12 +245,12 @@ void Display(void * parameter) {
 
 #ifdef USE_INFO_BUTTON
     if(print_info){
-      print_info = false;
       displayInfo(readBatLevel());
       delay(2000); //this delay only hangs up the thread for the display and not the main code, so it's ok here
       //retrigger force display
       prevForce = LONG_MIN;
       prevMaxForce = LONG_MIN;
+      print_info = false;
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,10 +23,15 @@ Tested with and recommended for Heltec WifiKit32 V2 or V3 controller
 #include "OneButton.h"
 #endif
 
-#define CSV_NAME "/slackcell.txt" // TODO: not sure if these should live in another file
-#define CSV_HEADER "Reading ID, Time (ms), Force (N) \r\n"
-#define SD_MESSAGE_LENGTH 60
-#define SD_START_DELAY 2000
+const char *CSV_NAME = "/slackcell.txt"; // TODO: not sure if these should live in another file
+const char *CSV_HEADER = 
+  "Reading ID, Time (ms),"
+#ifdef RECORD_BATTERY_VOLTAGE
+  " Battery Voltage (V),"
+#endif
+  " Force (N) \r\n";
+const unsigned int SD_MESSAGE_LENGTH  = 60;
+const uint32_t SD_START_DELAY = 2000;
 
 #define TARE_AVERAGE_TIME 30
 #define MAX_TARE_VALUE 30
@@ -245,7 +250,7 @@ void Display(void * parameter) {
 
 #ifdef USE_INFO_BUTTON
     if(print_info){
-      displayInfo(readBatLevel());
+      displayInfo(batteryVoltage);
       delay(2000); //this delay only hangs up the thread for the display and not the main code, so it's ok here
       //retrigger force display
       prevForce = LONG_MIN;
@@ -278,6 +283,10 @@ void writeSD(int readingID, long timeNow, long force) {
   sdMessage += ",";
   sdMessage += timeNow;
   sdMessage += ",";
+#ifdef RECORD_BATTERY_VOLTAGE
+  sdMessage += batteryVoltage; //TODO: if this stays, pass it through a parameter in the function
+  sdMessage += ",";
+#endif
   sdMessage += force;
   sdMessage += "\n";
   appendFile(SD, CSV_NAME, sdMessage.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,6 @@ void writeFile(fs::FS &fs, const char * path, const char * message);
 void appendFile(fs::FS &fs, const char * path, const char * message);
 void Display(void * parameter);
 
-long info_print_time;
 
 #ifdef USE_VSPI
 SPIClass spiVspi(VSPI);
@@ -77,8 +76,6 @@ long maxForce = 0;
 long force = -1;
 long reading = -1;
 long avg_reading = 0;
-long prevForce = -100;
-long prevMaxForce = -100;
 
 // TODO: should be selectable with buttons, maybe a small menu?
 bool recording = true;
@@ -246,16 +243,28 @@ void loop() {
 }
 
 void Display(void * parameter) {
+  static long prevForce = LONG_MIN;
+  static long prevMaxForce = LONG_MIN;
+  static uint8_t prevBatteryPercent = 0;
   for(;;){
 
 #ifdef USE_INFO_BUTTON
     if(print_info){
-      displayInfo(batteryVoltage);
+      displayInfo(batteryVoltage, batteryPercent);
       delay(2000); //this delay only hangs up the thread for the display and not the main code, so it's ok here
+      displayClearBuffer();
       //retrigger force display
       prevForce = LONG_MIN;
       prevMaxForce = LONG_MIN;
+      prevBatteryPercent = UINT8_MAX;
       print_info = false;
+    }
+#endif
+
+#ifdef HAS_BATTERY_READOUT
+    if(batteryPercent != prevBatteryPercent){
+      prevBatteryPercent = batteryPercent;
+      displayBatteryIcon(batteryPercent);
     }
 #endif
 

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -5,6 +5,7 @@
 #include "OneButton.h"
 #include "driver/rtc_io.h"
 #include "display.h"
+#include "power.h"
 
 
 //in minutes
@@ -12,8 +13,19 @@ const int STANDBY_TIME = 5;
 //in newtons
 const int STANDBY_UNDER_FORCE = 15;
 
+#ifdef USE_SLEEP
+const unsigned long MIN_POWER_BUTTON_DURATION_FOR_WAKEUP = 1500;
+const unsigned long MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN = 2000;
+
+#ifdef HAS_BATTERY_READOUT
+const float MIN_OPERATING_BAT_VOL = 3.3; //In V, MCU will shut down if battery voltage drops below this value
+const float CRITICAL_BAT_VOL = 3.1; //Do nothing if the voltage drops below this, not even display the warning about low battery
+const unsigned long BATTERY_READOUT_INTERVAL = 1000;
+#endif //HAS_BATTERY_READOUT
+#endif //SLEEP
+
 long lastTimeOverStandbyLimit = 0;
-bool wakingUp = false;
+bool wakingUp = false; //set by power button callback (wakeUp)
 
 //could be controlled later by the user
 //if set from false to true, lastTimeOverStandbyLimit must be set before to millis() to prevent immediate standby
@@ -37,23 +49,43 @@ void VextOFF(void);
 /// This function get's called directly after the mcu got reset or waked out of sleep.
 /// If the mcu woke up from sleep through a button press, the button needs to be held down for a while longer, to really start the SlackCell.
 /// This prevents accidental power on from short bump of the power button.
+/// It will also refuse to boot if the battery volage is too low.
 void maybeWakeUp(){
 #ifdef USE_SLEEP
   if(esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0){
+    //A press of the power button woke up the mcu.
+#ifdef HAS_BATTERY_READOUT
+    if(readBatLevel() < CRITICAL_BAT_VOL){
+      //if the battery is really low, go back to sleep directly, without using any more energy on awaiting a long button press or turning on the display
+      goToSleep();
+    }
+#endif
+    //To be sure the user really wants to turn the SlackCell on, a long press of the power button is expected
     power_btn.attachLongPressStart(wakeUp);
-    power_btn.setPressMs(3500);
+    power_btn.setPressMs(MIN_POWER_BUTTON_DURATION_FOR_WAKEUP);
 
-    long boot_time = millis();
-    while(millis() - boot_time < 4000){
+    //Keep checking the button during a timeout a little bit longer than the expected duration of the long press of the power button
+    //directly after wakeup, millis() is always zero, so we can use absolute values instead of comparing to a timestamp here
+    while(millis() < MIN_POWER_BUTTON_DURATION_FOR_WAKEUP + 500){
       power_btn.tick();
-      if(wakingUp){
-        return;
+      if(wakingUp){ //"wakingUp" gets set to true as sideeffect of the callback for the power_btn set above
+#ifdef HAS_BATTERY_READOUT
+        if(readBatLevel() < MIN_OPERATING_BAT_VOL){
+          //but if it just crossed the threshold, inform the user about the low battery
+          displayInit();
+          displayBatteryLow();
+          delay(1500);
+          goToSleep();
+        }
+#endif //HAS_BATTERY_READOUT
+        return; //continue booting
         lastTimeOverStandbyLimit = millis();
       }
     }
-    //if 4 seconds pass without detecting a long press, go back to sleep
+    //if specified time passes without detecting a long press, go back to sleep
     goToSleep();
   }
+  //on other wakeup reasons always wake up
 #endif
 }
 
@@ -67,7 +99,7 @@ void powerInit(){
 
 #ifdef USE_SLEEP
     power_btn.attachLongPressStart(goToSleep);
-    power_btn.setPressMs(3000);
+    power_btn.setPressMs(MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN);
 #endif
 }
 
@@ -76,6 +108,19 @@ void powerTick(long reading){
     unsigned long timeNow = millis();
 
     power_btn.tick();
+
+#ifdef HAS_BATTERY_READOUT
+    static unsigned long last_battery_readout_time;
+
+    if(millis() - last_battery_readout_time > BATTERY_READOUT_INTERVAL){
+      last_battery_readout_time = timeNow;
+      if(readBatLevel() < MIN_OPERATING_BAT_VOL){
+        displayBatteryLow();
+        delay(1500);
+        goToSleep();
+      }
+    }
+#endif //HAS_BATTERY_READOUT
     
     if(!automaticStandbyActive){
       return;
@@ -101,7 +146,6 @@ void goToSleep(){
   digitalWrite(LOADCELL_SCK_PIN, HIGH);
 #endif
 
-  Serial.printf("Deep sleeping until power button is pressed again");
   esp_sleep_enable_ext0_wakeup(POWER_BUTTON_PIN, LOW);
   // Configure pullup/downs via RTCIO to tie wakeup pins to inactive level during deepsleep.
   // EXT0 resides in the same power domain (RTC_PERIPH) as the RTC IO pullup/downs.
@@ -112,11 +156,28 @@ void goToSleep(){
 
   // Delaying the final call to sleep, to prevent bouncing of the button from waking up the device directly again.
   // By this time user probably got bored pressing the button and button bouncing should be over.
-  delay(2000);
+  delay(1000);
+  Serial.printf("Deep sleeping until power button is pressed again");
 
   esp_deep_sleep_start();
 }
 #endif //USE_SLEEP
+
+#ifdef HAS_BATTERY_READOUT
+//The Heltec V3 has a voltage divider connected to the battery, which needs to be activated with another GPIO pin.
+//Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
+float readBatLevel() {
+  pinMode(VBAT_READ_CONTROL_PIN, OUTPUT);
+  digitalWrite(VBAT_READ_CONTROL_PIN, LOW);
+  
+  analogSetPinAttenuation(VBAT_ADC_PIN, VBAT_ADC_ATTENUATION);
+  float voltage = analogReadMilliVolts(VBAT_ADC_PIN) * VBAT_CONVERSION_FACTOR;
+
+  pinMode(VBAT_READ_CONTROL_PIN, INPUT);
+  return voltage;
+}
+#endif //HAS_BATTERY_READOUT
+
 
 #ifdef USE_VEXT
 // Turn external power supply on

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -1,0 +1,135 @@
+#include <Arduino.h>
+#include "pins.h"
+
+#ifdef USE_SLEEP
+#include "OneButton.h"
+#include "driver/rtc_io.h"
+#include "display.h"
+
+
+//in minutes
+const int STANDBY_TIME = 5;
+//in newtons
+const int STANDBY_UNDER_FORCE = 15;
+
+long lastTimeOverStandbyLimit = 0;
+bool wakingUp = false;
+
+//could be controlled later by the user
+//if set from false to true, lastTimeOverStandbyLimit must be set before to millis() to prevent immediate standby
+bool automaticStandbyActive = true;
+
+OneButton power_btn(POWER_BUTTON_PIN, true);
+
+void goToSleep();
+
+void wakeUp(){
+  wakingUp = true;
+}
+#endif //USE SLEEP
+
+#ifdef USE_VEXT
+void VextON(void);
+void VextOFF(void);
+#endif
+
+
+/// This function get's called directly after the mcu got reset or waked out of sleep.
+/// If the mcu woke up from sleep through a button press, the button needs to be held down for a while longer, to really start the SlackCell.
+/// This prevents accidental power on from short bump of the power button.
+void maybeWakeUp(){
+#ifdef USE_SLEEP
+  if(esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0){
+    power_btn.attachLongPressStart(wakeUp);
+    power_btn.setPressMs(3500);
+
+    long boot_time = millis();
+    while(millis() - boot_time < 4000){
+      power_btn.tick();
+      if(wakingUp){
+        return;
+        lastTimeOverStandbyLimit = millis();
+      }
+    }
+    //if 4 seconds pass without detecting a long press, go back to sleep
+    goToSleep();
+  }
+#endif
+}
+
+void powerInit(){
+    maybeWakeUp();
+
+#ifdef USE_VEXT
+    //turn on external devices
+    VextON();
+#endif //USE_VEXT
+
+#ifdef USE_SLEEP
+    power_btn.attachLongPressStart(goToSleep);
+    power_btn.setPressMs(3000);
+#endif
+}
+
+void powerTick(long reading){
+#ifdef USE_SLEEP
+    unsigned long timeNow = millis();
+
+    power_btn.tick();
+    
+    if(!automaticStandbyActive){
+      return;
+    }
+
+    if(reading > STANDBY_UNDER_FORCE){
+      lastTimeOverStandbyLimit = timeNow;
+    } else if(timeNow - lastTimeOverStandbyLimit > 1000 * 60 * STANDBY_TIME){
+      goToSleep();
+    }
+#endif
+}
+
+#ifdef USE_SLEEP
+void goToSleep(){
+  Serial.println("Getting ready for sleeping ...");
+  // Turn off display
+  displaySleep();
+#ifdef USE_VEXT
+  VextOFF();
+#else
+  // Put hx711 to sleep, only needed if not controlled through external power
+  digitalWrite(LOADCELL_SCK_PIN, HIGH);
+#endif
+
+  Serial.printf("Deep sleeping until power button is pressed again");
+  esp_sleep_enable_ext0_wakeup(POWER_BUTTON_PIN, LOW);
+  // Configure pullup/downs via RTCIO to tie wakeup pins to inactive level during deepsleep.
+  // EXT0 resides in the same power domain (RTC_PERIPH) as the RTC IO pullup/downs.
+  // No need to keep that power domain explicitly, unlike EXT1.
+  rtc_gpio_pullup_en(POWER_BUTTON_PIN);
+  rtc_gpio_pulldown_dis(POWER_BUTTON_PIN);
+  Serial.flush();
+
+  // Delaying the final call to sleep, to prevent bouncing of the button from waking up the device directly again.
+  // By this time user probably got bored pressing the button and button bouncing should be over.
+  delay(2000);
+
+  esp_deep_sleep_start();
+}
+#endif //USE_SLEEP
+
+#ifdef USE_VEXT
+// Turn external power supply on
+void VextON(void)
+{
+  pinMode(Vext,OUTPUT);
+  digitalWrite(Vext, LOW);
+}
+
+//Turn external power supply off
+void VextOFF(void) //Vext default OFF
+{
+  pinMode(Vext,OUTPUT);
+  digitalWrite(Vext, HIGH);
+}
+#endif //USE_VEXT

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -20,7 +20,8 @@ const unsigned long MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN = 2000;
 #ifdef HAS_BATTERY_READOUT
 const float MIN_OPERATING_BAT_VOL = 3.3; //In V, MCU will shut down if battery voltage drops below this value
 const float CRITICAL_BAT_VOL = 3.1; //Do nothing if the voltage drops below this, not even display the warning about low battery
-const unsigned long BATTERY_READOUT_INTERVAL = 1000;
+const unsigned long BATTERY_READOUT_INTERVAL = 3000;
+static const uint8_t BATTERY_READING_AVG_TIMES = 200;
 #endif //HAS_BATTERY_READOUT
 
 long lastTimeOverStandbyLimit = 0;
@@ -36,6 +37,7 @@ bool automaticStandbyActive = true;
 OneButton power_btn(POWER_BUTTON_PIN, true);
 
 void goToSleep();
+void batteryReadoutInit();
 
 void wakeUp(){
   wakingUp = true;
@@ -94,16 +96,19 @@ void maybeWakeUp(){
 }
 
 void powerInit(){
-    maybeWakeUp();
+#ifdef HAS_BATTERY_READOUT
+  batteryReadoutInit();
+#endif
+  maybeWakeUp();
 
 #ifdef USE_VEXT
-    //turn on external devices
-    VextON();
+  //turn on external devices
+  VextON();
 #endif //USE_VEXT
 
 #ifdef USE_SLEEP
-    power_btn.attachLongPressStart(goToSleep);
-    power_btn.setPressMs(MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN);
+  power_btn.attachLongPressStart(goToSleep);
+  power_btn.setPressMs(MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN);
 #endif
 }
 
@@ -115,20 +120,31 @@ void powerTick(long reading){
 
 #ifdef HAS_BATTERY_READOUT
     static unsigned long last_battery_readout_time;
+    static uint8_t battery_reading_id = 0;
+    static float battery_voltage_sum = 0;
 
-    if(millis() - last_battery_readout_time > BATTERY_READOUT_INTERVAL){
+    if(timeNow - last_battery_readout_time > BATTERY_READOUT_INTERVAL / BATTERY_READING_AVG_TIMES){
       last_battery_readout_time = timeNow;
-      batteryVoltage = readBatLevel();
 
-      if(batteryVoltage < MIN_OPERATING_BAT_VOL){
-        displayBatteryLow();
-        delay(1500);
-        goToSleep();
+      battery_voltage_sum += readBatLevel();
+      //cycle battery_reading_id from 0 to BATTERY_READING_AVG_TIMES - 1
+      battery_reading_id = ++battery_reading_id % BATTERY_READING_AVG_TIMES;
+
+      //update batteryVoltage only when enough values are collected
+      if(battery_reading_id == 0){
+        batteryVoltage = battery_voltage_sum / BATTERY_READING_AVG_TIMES;
+        battery_voltage_sum = 0;
+
+        if(batteryVoltage < MIN_OPERATING_BAT_VOL){
+          displayBatteryLow();
+          delay(1500);
+          goToSleep();
+        }
+
+        //batteryPercent is changed after the check for sufficient battery voltage to avoid the battery icon displaying on top of the "battery too low" warning.
+        //using a precalculated lookup table to convert voltage into approximate percent, is non linear
+        batteryPercent = battery_percent_lut[constrain(int(round(batteryVoltage*100)), min_lut_voltage, max_lut_voltage) - min_lut_voltage];
       }
-
-      //batteryPercent is changed after the check for sufficient battery voltage to avoid the battery icon displaying on top of the "battery too low" warning.
-      //using a precalculated lookup table to convert voltage into approximate percent, is non linear
-      batteryPercent = battery_percent_lut[constrain(int(round(batteryVoltage*100)), min_lut_voltage, max_lut_voltage) - min_lut_voltage];
     }
 #endif //HAS_BATTERY_READOUT
     
@@ -171,22 +187,23 @@ void goToSleep(){
 
   esp_deep_sleep_start();
 }
-#endif //USE_SLEEP
 
 #ifdef HAS_BATTERY_READOUT
-//The Heltec V3 has a voltage divider connected to the battery, which needs to be activated with another GPIO pin.
-//Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
-float readBatLevel() {
+void batteryReadoutInit(){
+  //control pin needed to active battery voltage readout
   pinMode(VBAT_READ_CONTROL_PIN, OUTPUT);
   digitalWrite(VBAT_READ_CONTROL_PIN, LOW);
   
   analogSetPinAttenuation(VBAT_ADC_PIN, VBAT_ADC_ATTENUATION);
-  float voltage = analogReadMilliVolts(VBAT_ADC_PIN) * VBAT_CONVERSION_FACTOR;
+}
 
-  pinMode(VBAT_READ_CONTROL_PIN, INPUT);
-  return voltage;
+//The Heltec V3 has a voltage divider connected to the battery, which needs to be activated with another GPIO pin.
+//Schematic for the Heltec V3, relevant is the bottom left section: https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf
+float readBatLevel() {
+  return analogReadMilliVolts(VBAT_ADC_PIN) * VBAT_CONVERSION_FACTOR * VBAT_CORRECTION_FACTOR;
 }
 #endif //HAS_BATTERY_READOUT
+#endif //USE_SLEEP
 
 
 #ifdef USE_VEXT

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -27,6 +27,8 @@ const unsigned long BATTERY_READOUT_INTERVAL = 1000;
 long lastTimeOverStandbyLimit = 0;
 bool wakingUp = false; //set by power button callback (wakeUp)
 
+float batteryVoltage;
+
 //could be controlled later by the user
 //if set from false to true, lastTimeOverStandbyLimit must be set before to millis() to prevent immediate standby
 bool automaticStandbyActive = true;
@@ -114,7 +116,9 @@ void powerTick(long reading){
 
     if(millis() - last_battery_readout_time > BATTERY_READOUT_INTERVAL){
       last_battery_readout_time = timeNow;
-      if(readBatLevel() < MIN_OPERATING_BAT_VOL){
+      batteryVoltage = readBatLevel();
+
+      if(batteryVoltage < MIN_OPERATING_BAT_VOL){
         displayBatteryLow();
         delay(1500);
         goToSleep();

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -6,6 +6,7 @@
 #include "driver/rtc_io.h"
 #include "display.h"
 #include "power.h"
+#include "user_config.h"
 
 
 //in minutes
@@ -13,7 +14,6 @@ const int STANDBY_TIME = 5;
 //in newtons
 const int STANDBY_UNDER_FORCE = 15;
 
-#ifdef USE_SLEEP
 const unsigned long MIN_POWER_BUTTON_DURATION_FOR_WAKEUP = 1500;
 const unsigned long MIN_POWER_BUTTON_DURATION_FOR_SHUTDOWN = 2000;
 
@@ -22,11 +22,11 @@ const float MIN_OPERATING_BAT_VOL = 3.3; //In V, MCU will shut down if battery v
 const float CRITICAL_BAT_VOL = 3.1; //Do nothing if the voltage drops below this, not even display the warning about low battery
 const unsigned long BATTERY_READOUT_INTERVAL = 1000;
 #endif //HAS_BATTERY_READOUT
-#endif //SLEEP
 
 long lastTimeOverStandbyLimit = 0;
 bool wakingUp = false; //set by power button callback (wakeUp)
 
+uint8_t batteryPercent;
 float batteryVoltage;
 
 //could be controlled later by the user
@@ -54,14 +54,16 @@ void VextOFF(void);
 /// It will also refuse to boot if the battery volage is too low.
 void maybeWakeUp(){
 #ifdef USE_SLEEP
+
+#ifdef HAS_BATTERY_READOUT
+  if(readBatLevel() < CRITICAL_BAT_VOL){
+    //if the battery is really low, go back to sleep directly, without using any more energy on awaiting a long button press or turning on the display
+    goToSleep();
+  }
+#endif
+
   if(esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_EXT0){
     //A press of the power button woke up the mcu.
-#ifdef HAS_BATTERY_READOUT
-    if(readBatLevel() < CRITICAL_BAT_VOL){
-      //if the battery is really low, go back to sleep directly, without using any more energy on awaiting a long button press or turning on the display
-      goToSleep();
-    }
-#endif
     //To be sure the user really wants to turn the SlackCell on, a long press of the power button is expected
     power_btn.attachLongPressStart(wakeUp);
     power_btn.setPressMs(MIN_POWER_BUTTON_DURATION_FOR_WAKEUP);
@@ -88,7 +90,7 @@ void maybeWakeUp(){
     goToSleep();
   }
   //on other wakeup reasons always wake up
-#endif
+#endif //USE_SLEEP
 }
 
 void powerInit(){
@@ -123,6 +125,10 @@ void powerTick(long reading){
         delay(1500);
         goToSleep();
       }
+
+      //batteryPercent is changed after the check for sufficient battery voltage to avoid the battery icon displaying on top of the "battery too low" warning.
+      //using a precalculated lookup table to convert voltage into approximate percent, is non linear
+      batteryPercent = battery_percent_lut[constrain(int(round(batteryVoltage*100)), min_lut_voltage, max_lut_voltage) - min_lut_voltage];
     }
 #endif //HAS_BATTERY_READOUT
     


### PR DESCRIPTION
When the HX711/SD module are connected to a switchable Supply, this enables leaving a battery connected permanently. The Heltec V3 manages a deep sleep current of 10 uA.

Sleep can be activated manually by pressing the configured power button for a couple of seconds.

Additionally, sleep will be activated automatically if the force is for a configured time (example 5min) under the configured force limit. This means that standby will not activate while measuring forces in a slackline, only while it is lying around unused.

